### PR TITLE
Update TerritoryType pointer and CompanyTag offset

### DIFF
--- a/definitions/FFXIV/dx11/2019.11.06.0000.0000.json
+++ b/definitions/FFXIV/dx11/2019.11.06.0000.0000.json
@@ -2,7 +2,7 @@
   "TerritoryType": {
     "PointerPath": [
 		29327616,
-		628
+		1578
     ],
     "Module": {
       "ModuleName": "ffxiv_dx11.exe"
@@ -42,7 +42,7 @@
   "Level": 6390,
   "World": 6308,
   "HomeWorld": 6310,
-  "CompanyTag": 6150,
+  "CompanyTag": 6138,
   "Customize": 5768,
   "RenderMode": 260,
   "ObjectKind": 140,


### PR DESCRIPTION
Make sure this is sane/test if possible.

The TerritoryType pointer was a bit odd - there appears to be a fixed offset for the value that doesn't need a pointer at all (at 0x1BF8732), but I kept it as a pointer to change as little as possible.

I also had to tell CE to ignore 32-bit alignment in order to find it, which I thought was questionable.  Without that option, it finds the pointer value that was in the json definitions before, but that points to memory 2 bytes below the actual location we want...