### PR TITLE
Update TerritoryType to fixed reference instead of pointer value

### DIFF
--- a/Nhaama.FFXIV/Definitions.cs
+++ b/Nhaama.FFXIV/Definitions.cs
@@ -10,7 +10,6 @@ namespace Nhaama.FFXIV
     {
         public Definitions(NhaamaProcess process)
         {
-            TerritoryType = new Pointer(process, 0x1AE5A88, 0x5A8);
             Time = new Pointer(process, 0x1A8D3C0);
             Weather = new Pointer(process, 0x1A62448);
             LocalContentId = new Pointer(process, 0x1B58B60);
@@ -19,10 +18,11 @@ namespace Nhaama.FFXIV
         [JsonConstructor]
         private Definitions() {}
 
-        public Pointer TerritoryType;
         public Pointer Time;
         public Pointer Weather;
         public Pointer LocalContentId;
+
+        public ulong TerritoryType = 0x1BF8732;
 
         public ulong ActorTable = 0x1AA97B8;
 

--- a/Nhaama.FFXIV/Game.cs
+++ b/Nhaama.FFXIV/Game.cs
@@ -46,9 +46,7 @@ namespace Nhaama.FFXIV
         {
             ActorTable.Update();
 
-            Definitions.TerritoryType.Resolve(Process);
-            TerritoryType = Process.ReadUInt16(Definitions.TerritoryType);
-
+            TerritoryType = Process.ReadUInt16(Process.GetModuleBasedOffset("ffxiv_dx11.exe", Definitions.TerritoryType));
             LocalContentId = Process.ReadUInt64(Definitions.LocalContentId);
         }
     }

--- a/definitions/FFXIV/dx11/2019.11.19.0000.0000.json
+++ b/definitions/FFXIV/dx11/2019.11.19.0000.0000.json
@@ -1,13 +1,4 @@
 {
-  "TerritoryType": {
-    "PointerPath": [
-		29327616,
-		1578
-    ],
-    "Module": {
-      "ModuleName": "ffxiv_dx11.exe"
-    }
-  },
   "Time": {
     "PointerPath": [
       27841472
@@ -32,6 +23,7 @@
       "ModuleName": "ffxiv_dx11.exe"
     }
   },
+  "TerritoryType": 29329202,
   "ActorTable": 29347216,
   "ActorID": 116,
   "Name": 48,


### PR DESCRIPTION
This is using the fixed offset that I found last patch, which is apparently still valid.

The pointer version is unstable - in a single playthrough, it started out not working, then started working for a while, and then broke again.  When it is broken, CE pointer scans fail against all 5 of the high memory locations holding the territory value.

This fixed offset persisted across multiple restarts and seemed to always be valid when playing for a while.

I wasn't sure if there was a better way than using Process.GetModuleBasedOffset() - I just copied what is done for ActorTable