### PR TITLE
Update actor table location

### DIFF
--- a/definitions/FFXIV/dx11/2019.12.05.0000.0000.json
+++ b/definitions/FFXIV/dx11/2019.12.05.0000.0000.json
@@ -24,7 +24,7 @@
     }
   },
   "TerritoryType": 29329202,
-  "ActorTable": 29347216,
+  "ActorTable": 29375032,
   "ActorID": 116,
   "Name": 48,
   "BnpcBase": 128,


### PR DESCRIPTION
Please test this first.  It seems correct, but I never really played with the actor table much before so I'm not certain if there are other locations etc.

I didn't look into anything else yet, but the suboffsets for things like fc tag/home and current world/job/level all looked good still.