### PR TITLE
Add 5.18 definitions file, with updated TerritoryType and ActorTable

### DIFF
--- a/definitions/FFXIV/dx11/2019.12.19.0000.0000.json
+++ b/definitions/FFXIV/dx11/2019.12.19.0000.0000.json
@@ -1,0 +1,54 @@
+{
+  "Time": {
+    "PointerPath": [
+      27841472
+    ],
+    "Module": {
+      "ModuleName": "ffxiv_dx11.exe"
+    }
+  },
+  "Weather": {
+    "PointerPath": [
+      27665480
+    ],
+    "Module": {
+      "ModuleName": "ffxiv_dx11.exe"
+    }
+  },
+  "LocalContentId": {
+    "PointerPath": [
+      29548544
+    ],
+    "Module": {
+      "ModuleName": "ffxiv_dx11.exe"
+    }
+  },
+  "TerritoryType": 29341490,
+  "ActorTable": 29359504,
+  "ActorID": 116,
+  "Name": 48,
+  "BnpcBase": 128,
+  "OwnerID": 132,
+  "ModelChara": 5884,
+  "Job": 6388,
+  "Level": 6390,
+  "World": 6308,
+  "HomeWorld": 6310,
+  "CompanyTag": 6138,
+  "Customize": 5768,
+  "RenderMode": 260,
+  "ObjectKind": 140,
+  "SubKind": 141,
+  "Head": 5608,
+  "Body": 5612,
+  "Hands": 5616,
+  "Legs": 5620,
+  "Feet": 5624,
+  "Ear": 5628,
+  "Neck": 5632,
+  "Wrist": 5636,
+  "RRing": 5640,
+  "LRing": 5644,
+  "MainWep": 4930,
+  "OffWep": 5032
+}


### PR DESCRIPTION
Using Johto's value for the actor table.  We both found the same value for TerritoryType, but I couldn't get the actor table due to my game issues.

Their layout is similar with the table base and then offsets for individual actors, and the values that both projects used all seem to match so I am reasonably sure this should work the same.