### PR TITLE
5.2 updates

### DIFF
--- a/Nhaama.FFXIV/Definitions.cs
+++ b/Nhaama.FFXIV/Definitions.cs
@@ -13,6 +13,7 @@ namespace Nhaama.FFXIV
             Time = new Pointer(process, 0x1A8D3C0);
             Weather = new Pointer(process, 0x1A62448);
             LocalContentId = new Pointer(process, 0x1B58B60);
+            TerritoryType = new Pointer(process, 0x1CB2E70, 0x12);
         }
         
         [JsonConstructor]
@@ -22,7 +23,7 @@ namespace Nhaama.FFXIV
         public Pointer Weather;
         public Pointer LocalContentId;
 
-        public ulong TerritoryType = 0x1BF8732;
+        public Pointer TerritoryType;
 
         public ulong ActorTable = 0x1AA97B8;
 

--- a/Nhaama.FFXIV/Game.cs
+++ b/Nhaama.FFXIV/Game.cs
@@ -46,7 +46,9 @@ namespace Nhaama.FFXIV
         {
             ActorTable.Update();
 
-            TerritoryType = Process.ReadUInt16(Process.GetModuleBasedOffset("ffxiv_dx11.exe", Definitions.TerritoryType));
+            Definitions.TerritoryType.Resolve(Process);
+            TerritoryType = Process.ReadUInt16(Definitions.TerritoryType);
+
             LocalContentId = Process.ReadUInt64(Definitions.LocalContentId);
         }
     }

--- a/definitions/FFXIV/dx11/2020.02.11.0000.0000.json
+++ b/definitions/FFXIV/dx11/2020.02.11.0000.0000.json
@@ -1,0 +1,63 @@
+{
+  "Time": {
+    "PointerPath": [
+      27841472
+    ],
+    "Module": {
+      "ModuleName": "ffxiv_dx11.exe"
+    }
+  },
+  "Weather": {
+    "PointerPath": [
+      27665480
+    ],
+    "Module": {
+      "ModuleName": "ffxiv_dx11.exe"
+    }
+  },
+  "LocalContentId": {
+    "PointerPath": [
+      29548544
+    ],
+    "Module": {
+      "ModuleName": "ffxiv_dx11.exe"
+    }
+  },
+  "TerritoryType": {
+    "PointerPath": [
+	  30092912,
+	  18
+	],
+	"Module": {
+	  "ModuleName": "ffxiv_dx11.exe"
+	}
+  },
+  
+  "ActorTable": 29762072,
+  "ActorID": 116,
+  "Name": 48,
+  "BnpcBase": 128,
+  "OwnerID": 132,
+  "ModelChara": 5884,
+  "Job": 6358,
+  "Level": 6360,
+  "World": 6276,
+  "HomeWorld": 6278,
+  "CompanyTag": 6098,
+  "Customize": 5768,
+  "RenderMode": 260,
+  "ObjectKind": 140,
+  "SubKind": 141,
+  "Head": 5608,
+  "Body": 5612,
+  "Hands": 5616,
+  "Legs": 5620,
+  "Feet": 5624,
+  "Ear": 5628,
+  "Neck": 5632,
+  "Wrist": 5636,
+  "RRing": 5640,
+  "LRing": 5644,
+  "MainWep": 4930,
+  "OffWep": 5032
+}


### PR DESCRIPTION
XIVLauncher will need to have its Nhaama submodule reference updated to include these, due to the TerritoryType change to a pointer.  I can't PR that because this commit has to be merged first.